### PR TITLE
fix: prevent AF_UNIX socket path exceeding 108-byte limit

### DIFF
--- a/mcp_launchpad/platform.py
+++ b/mcp_launchpad/platform.py
@@ -178,6 +178,38 @@ def get_log_file_path() -> Path:
         return Path("/tmp") / f"mcpl-{uid}-{session_id}.log"
 
 
+def get_legacy_socket_path() -> Path | None:
+    """Get old-format socket path (pre-v0.x.x) for migration detection.
+
+    Old format used tempfile.gettempdir() and unhashed session IDs.
+    Returns None on Windows (no migration needed - Windows uses named pipes).
+
+    Used during upgrade to detect and clean up legacy daemons.
+    """
+    if IS_WINDOWS:
+        return None  # Windows uses named pipes, no migration needed
+
+    session_id = get_session_id()  # Raw, unhashed
+    uid = os.getuid()
+    return Path(tempfile.gettempdir()) / f"mcpl-{uid}-{session_id}.sock"
+
+
+def get_legacy_pid_file_path() -> Path | None:
+    """Get old-format PID file path (pre-v0.x.x) for migration detection.
+
+    Old format used tempfile.gettempdir() and unhashed session IDs.
+    Returns None on Windows (no migration needed).
+
+    Used during upgrade to detect and clean up legacy daemons.
+    """
+    if IS_WINDOWS:
+        return None  # Windows uses named pipes, no migration needed
+
+    session_id = get_session_id()  # Raw, unhashed
+    uid = os.getuid()
+    return Path(tempfile.gettempdir()) / f"mcpl-{uid}-{session_id}.pid"
+
+
 def is_process_alive(pid: int) -> bool:
     """Check if a process with the given PID is still running.
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -7,7 +7,12 @@ import pytest
 
 from mcp_launchpad.platform import (
     IS_WINDOWS,
+    MAX_SESSION_ID_LEN,
+    _shorten_session_id,
     get_ide_session_anchor,
+    get_legacy_pid_file_path,
+    get_legacy_socket_path,
+    get_log_file_path,
     get_parent_pid,
     get_pid_file_path,
     get_session_id,
@@ -115,6 +120,16 @@ class TestGetSessionId:
             "VSCODE_GIT_IPC_HANDLE", "/var/folders/xx/vscode-git-abc123def.sock"
         )
         assert get_session_id() == "vscode-abc123def"
+
+    def test_vscode_git_ipc_no_match_falls_through(self, monkeypatch):
+        """Test that non-matching VS Code Git IPC handle falls through to next check."""
+        monkeypatch.delenv("MCPL_SESSION_ID", raising=False)
+        monkeypatch.delenv("TERM_SESSION_ID", raising=False)
+        # Set a handle that doesn't match the vscode-git-{hex}.sock pattern
+        monkeypatch.setenv("VSCODE_GIT_IPC_HANDLE", "/some/other/path/socket.sock")
+        # Should fall through to CLAUDE_CODE_SSE_PORT
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "54321")
+        assert get_session_id() == "claude-54321"
 
     def test_uses_claude_code_sse_port(self, monkeypatch):
         """Test that Claude Code SSE port is used when no Git IPC handle."""
@@ -272,3 +287,203 @@ class TestGetParentPid:
         """Test that parent PID is not the current process."""
         parent_pid = get_parent_pid()
         assert parent_pid != os.getpid()
+
+
+class TestShortenSessionId:
+    """Tests for _shorten_session_id function."""
+
+    def test_short_id_unchanged(self):
+        """Test that short session IDs are not modified."""
+        short_id = "abc123"
+        assert _shorten_session_id(short_id) == short_id
+
+    def test_exact_max_length_unchanged(self):
+        """Test that session ID at exactly max length is not modified."""
+        exact_id = "a" * MAX_SESSION_ID_LEN
+        assert _shorten_session_id(exact_id) == exact_id
+
+    def test_long_id_is_hashed(self):
+        """Test that long session IDs are hashed."""
+        long_id = "w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594"
+        result = _shorten_session_id(long_id)
+        # Should be shortened to max length
+        assert len(result) == MAX_SESSION_ID_LEN
+        # Original should not appear
+        assert long_id not in result
+        # Should be hexadecimal (MD5 hash)
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_hashing_is_deterministic(self):
+        """Test that hashing produces consistent results."""
+        long_id = "some-very-long-session-id-that-exceeds-limit"
+        result1 = _shorten_session_id(long_id)
+        result2 = _shorten_session_id(long_id)
+        assert result1 == result2
+
+    def test_different_long_ids_produce_different_hashes(self):
+        """Test that different long IDs produce different hashes."""
+        id1 = "first-very-long-session-id-12345"
+        id2 = "second-very-long-session-id-67890"
+        result1 = _shorten_session_id(id1)
+        result2 = _shorten_session_id(id2)
+        assert result1 != result2
+
+    def test_empty_string(self):
+        """Test that empty string is handled correctly."""
+        result = _shorten_session_id("")
+        assert result == ""
+
+
+class TestGetLegacySocketPath:
+    """Tests for get_legacy_socket_path function."""
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_returns_path_object(self, monkeypatch):
+        """Test that legacy socket path is a Path object."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_socket_path()
+        assert isinstance(path, Path)
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_uses_tempdir(self, monkeypatch):
+        """Test that legacy path uses tempfile.gettempdir()."""
+        import tempfile
+
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_socket_path()
+        # Legacy path should use tempdir, not /tmp directly
+        assert str(path).startswith(tempfile.gettempdir())
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_uses_unhashed_session_id(self, monkeypatch):
+        """Test that legacy path uses unhashed session ID."""
+        long_session = "w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594"
+        monkeypatch.setenv("MCPL_SESSION_ID", long_session)
+        path = get_legacy_socket_path()
+        # Legacy path should contain the full unhashed session ID
+        assert long_session in str(path)
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_differs_from_new_socket_path(self, monkeypatch):
+        """Test that legacy path differs from new path for long session IDs."""
+        long_session = "w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594"
+        monkeypatch.setenv("MCPL_SESSION_ID", long_session)
+        legacy_path = get_legacy_socket_path()
+        new_path = get_socket_path()
+        assert legacy_path != new_path
+
+    @pytest.mark.skipif(not IS_WINDOWS, reason="Windows-specific test")
+    def test_returns_none_on_windows(self, monkeypatch):
+        """Test that legacy socket path returns None on Windows."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_socket_path()
+        assert path is None
+
+
+class TestGetLegacyPidFilePath:
+    """Tests for get_legacy_pid_file_path function."""
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_returns_path_object(self, monkeypatch):
+        """Test that legacy PID file path is a Path object."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_pid_file_path()
+        assert isinstance(path, Path)
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_uses_tempdir(self, monkeypatch):
+        """Test that legacy path uses tempfile.gettempdir()."""
+        import tempfile
+
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_pid_file_path()
+        assert str(path).startswith(tempfile.gettempdir())
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_uses_unhashed_session_id(self, monkeypatch):
+        """Test that legacy path uses unhashed session ID."""
+        long_session = "w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594"
+        monkeypatch.setenv("MCPL_SESSION_ID", long_session)
+        path = get_legacy_pid_file_path()
+        assert long_session in str(path)
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_has_pid_extension(self, monkeypatch):
+        """Test that legacy PID file has .pid extension."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_pid_file_path()
+        assert path.suffix == ".pid"
+
+    @pytest.mark.skipif(not IS_WINDOWS, reason="Windows-specific test")
+    def test_returns_none_on_windows(self, monkeypatch):
+        """Test that legacy PID file path returns None on Windows."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_legacy_pid_file_path()
+        assert path is None
+
+
+class TestGetLogFilePath:
+    """Tests for get_log_file_path function."""
+
+    def test_returns_path_object(self, monkeypatch):
+        """Test that log file path is a Path object."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_log_file_path()
+        assert isinstance(path, Path)
+
+    def test_has_log_extension(self, monkeypatch):
+        """Test that log file has .log extension."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_log_file_path()
+        assert path.suffix == ".log"
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_unix_log_path_uses_tmp(self, monkeypatch):
+        """Test Unix log path uses /tmp directory."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "test-session")
+        path = get_log_file_path()
+        assert str(path).startswith("/tmp/")
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_long_session_id_is_hashed_in_log_path(self, monkeypatch):
+        """Test that long session IDs are hashed in log path."""
+        long_session = "w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594"
+        monkeypatch.setenv("MCPL_SESSION_ID", long_session)
+        path = get_log_file_path()
+        # Long session ID should not appear in the path
+        assert long_session not in str(path)
+
+
+class TestPathConsistency:
+    """Tests for consistency between path functions."""
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_socket_pid_log_use_same_session_id(self, monkeypatch):
+        """Test that socket, PID, and log paths use the same session ID portion."""
+        monkeypatch.setenv("MCPL_SESSION_ID", "consistent-session")
+        socket_path = str(get_socket_path())
+        pid_path = str(get_pid_file_path())
+        log_path = str(get_log_file_path())
+
+        # Extract session ID from each path (after uid and before extension)
+        uid = str(os.getuid())
+        socket_session = socket_path.split(f"mcpl-{uid}-")[1].split(".sock")[0]
+        pid_session = pid_path.split(f"mcpl-{uid}-")[1].split(".pid")[0]
+        log_session = log_path.split(f"mcpl-{uid}-")[1].split(".log")[0]
+
+        assert socket_session == pid_session == log_session
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Unix-specific test")
+    def test_all_paths_under_108_bytes(self, monkeypatch):
+        """Test that all paths stay under AF_UNIX 108 byte limit."""
+        # Use a very long session ID
+        long_session = "a" * 200
+        monkeypatch.setenv("MCPL_SESSION_ID", long_session)
+
+        socket_path = str(get_socket_path())
+        pid_path = str(get_pid_file_path())
+        log_path = str(get_log_file_path())
+
+        assert len(socket_path) < 108, f"Socket path too long: {len(socket_path)}"
+        assert len(pid_path) < 108, f"PID path too long: {len(pid_path)}"
+        assert len(log_path) < 108, f"Log path too long: {len(log_path)}"


### PR DESCRIPTION
## Summary
- Fix AF_UNIX socket path length overflow on macOS
- Use `/tmp` directly instead of `tempfile.gettempdir()` (which returns long paths on macOS like `/var/folders/.../T/`)
- Hash session IDs longer than 16 chars to ensure paths stay under the 108-byte limit

## Problem
On macOS, socket paths were exceeding the 108-byte AF_UNIX limit when:
1. `tempfile.gettempdir()` returned long paths (e.g., `/var/folders/hp/8m98jncj6jl51k6k5f99lc4w0000gn/T/`)
2. Session IDs contained UUIDs (e.g., `w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594` from `TERM_SESSION_ID`)

This caused the daemon to fail with:
```
OSError: AF_UNIX path too long
Socket path: /var/folders/hp/.../mcpl-501-w0t3p0:BBB00C6D-4693-42F2-9654-7FCE4CE0B594.sock
```

## Solution
1. Use `/tmp` directly on Unix (always short and writable)
2. Hash long session IDs (>16 chars) using MD5 prefix for uniqueness
3. Apply same fix to PID and log file paths for consistency

This ensures socket paths stay well under the limit (~40 chars max).

## Test plan
- [x] All existing tests pass (275 passed)
- [x] Added new test `test_long_session_id_is_hashed` to verify hashing behavior
- [x] Manually verified daemon starts successfully on macOS with long session IDs