### PR TITLE
Add SSE transport support for legacy MCP servers

### DIFF
--- a/mcp_launchpad/config.py
+++ b/mcp_launchpad/config.py
@@ -34,9 +34,10 @@ def _resolve_env_vars(value: str) -> str:
 class ServerConfig:
     """Configuration for a single MCP server.
 
-    Supports two transport types:
+    Supports three transport types:
     - stdio: Local process-based servers (command + args)
     - http: Remote HTTP-based servers (url + optional headers)
+    - sse: Remote SSE-based servers(url + args?)
     """
 
     name: str
@@ -55,7 +56,11 @@ class ServerConfig:
 
     def is_http(self) -> bool:
         """Check if this is an HTTP-based server."""
-        return self.server_type == "http"
+        return self.server_type in ("http", "sse")
+
+    def is_sse(self) -> bool:
+        """Check if this is a legacy SSE server (not streamable HTTP)."""
+        return self.server_type == "sse"
 
     def get_resolved_env(self) -> dict[str, str]:
         """Resolve environment variables, expanding ${VAR} references."""


### PR DESCRIPTION
## Summary
- Adds support for `type: "sse"` transport in mcp.json configuration
- Uses `mcp.client.sse.sse_client` from the MCP library for proper SSE handling
- Enables connection to MCP servers using the traditional SSE protocol

## Changes
- **config.py**: Added `is_sse()` method, updated `is_http()` to include SSE
- **connection.py**: Added `_connect_sse()` method, updated routing in `connect()`

## Testing
- All 466 existing tests pass
- Tested with three SSE servers (automem, graphkeep-tools, quint-code)
- Both `mcpl list` and `mcpl call` work correctly with `--no-daemon`

## Example Configuration
```json
{
  "mcpServers": {
    "my-sse-server": {
      "type": "sse",
      "url": "http://example.com/mcp/sse"
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)