### PR TITLE
feat(oauth): improve agent-friendly authentication

### DIFF
--- a/mcp_launchpad/cli.py
+++ b/mcp_launchpad/cli.py
@@ -1320,23 +1320,40 @@ def auth_status(ctx: click.Context, server: str | None) -> None:
             if status.authenticated:
                 if status.expired:
                     click.secho("  Status: ", nl=False)
-                    click.secho("expired", fg="yellow")
+                    click.secho("Expired", fg="yellow")
                 else:
                     click.secho("  Status: ", nl=False)
-                    click.secho("authenticated", fg="green")
+                    click.secho("Authenticated ✓", fg="green")
 
-                if status.expires_at:
-                    click.echo(f"  Expires: {status.expires_at}")
+                # Show access token expiry with human-readable time
+                if status.expires_in_human:
+                    expiry_color = "yellow" if status.expired else "green"
+                    click.echo("  Access Token: ", nl=False)
+                    click.secho(f"Expires in {status.expires_in_human}", fg=expiry_color)
+                elif status.expires_at:
+                    click.echo(f"  Access Token: Expires at {status.expires_at}")
+
+                # Show refresh token status with helpful message
+                if status.has_refresh_token:
+                    click.echo("  Refresh Token: ", nl=False)
+                    click.secho("Yes (auto-refresh enabled)", fg="green")
+                else:
+                    click.echo("  Refresh Token: ", nl=False)
+                    click.secho("No (re-auth required on expiry)", fg="yellow")
+
                 if status.scope:
                     click.echo(f"  Scopes: {status.scope}")
-                click.echo(f"  Has refresh token: {status.has_refresh_token}")
+
+                # Show when token was issued
+                if status.issued_ago_human:
+                    click.echo(f"  Issued: {status.issued_ago_human}")
 
                 if status.expired:
                     click.echo()
                     click.secho(f"  Run: mcpl auth login {server}", fg="cyan")
             else:
                 click.secho("  Status: ", nl=False)
-                click.secho("not authenticated", fg="red")
+                click.secho("Not authenticated", fg="red")
                 click.echo()
                 click.secho(f"  Run: mcpl auth login {server}", fg="cyan")
 

--- a/mcp_launchpad/config.py
+++ b/mcp_launchpad/config.py
@@ -58,6 +58,8 @@ class ServerConfig:
     oauth_client_id: str | None = None
     oauth_client_secret: str | None = None
     oauth_scopes: list[str] = field(default_factory=list)
+    # Static API key (alternative to OAuth for agent-friendly auth)
+    api_key: str | None = None
 
     def is_http(self) -> bool:
         """Check if this is an HTTP-based server."""
@@ -94,6 +96,12 @@ class ServerConfig:
         if self.oauth_client_secret is None:
             return None
         return _resolve_env_vars(self.oauth_client_secret)
+
+    def get_resolved_api_key(self) -> str | None:
+        """Resolve environment variables in API key."""
+        if self.api_key is None:
+            return None
+        return _resolve_env_vars(self.api_key)
 
 
 @dataclass
@@ -285,6 +293,8 @@ def parse_server_config(name: str, data: dict[str, Any]) -> ServerConfig:
         oauth_client_id=data.get("oauth_client_id"),
         oauth_client_secret=data.get("oauth_client_secret"),
         oauth_scopes=data.get("oauth_scopes", []),
+        # Static API key (alternative to OAuth)
+        api_key=data.get("api_key"),
     )
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -318,9 +318,10 @@ class TestOAuthRequiredError:
         message = str(error)
         # Should mention how to authenticate
         assert "mcpl auth login" in message
-        # Should mention alternative options
-        assert "headers" in message
-        assert "Bearer" in message
+        # Should mention alternative option (API key)
+        assert "api_key" in message
+        # Should mention agent/automated use
+        assert "agent" in message.lower() or "automated" in message.lower()
 
     def test_error_stores_attributes(self):
         """Test that error stores server_name, url, and www_authenticate."""
@@ -330,11 +331,14 @@ class TestOAuthRequiredError:
         assert error.url == "https://api.notion.com/mcp"
         assert error.www_authenticate == www_auth
 
-    def test_error_message_includes_github_issue_link(self):
-        """Test that error message includes the GitHub issue link for tracking."""
+    def test_error_message_includes_auth_status_hint(self):
+        """Test that error message includes auth status hint for troubleshooting."""
         error = OAuthRequiredError("notion", "https://api.notion.com/mcp")
-        assert "github.com" in str(error)
-        assert "issues/7" in str(error)
+        message = str(error)
+        # Should mention how to check auth status
+        assert "mcpl auth status" in message
+        # Should mention tokens persist across sessions
+        assert "persist" in message.lower() or "Tokens" in message
 
 
 class TestConnectionManagerOAuth:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -565,8 +565,8 @@ class TestDaemonOAuthHandling:
 
             # Should tell user how to authenticate
             assert "mcpl auth login" in error_msg
-            # Should suggest static headers as alternative
-            assert "headers" in error_msg
+            # Should suggest API key as alternative
+            assert "api_key" in error_msg
 
     @pytest.mark.asyncio
     async def test_non_401_http_error_still_retries(self, http_server_config):

--- a/tests/test_oauth_manager.py
+++ b/tests/test_oauth_manager.py
@@ -1,0 +1,148 @@
+"""Tests for OAuth manager module."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mcp_launchpad.oauth.manager import _format_timedelta, _format_time_ago
+
+
+class TestFormatTimedelta:
+    """Tests for _format_timedelta function."""
+
+    def test_negative_timedelta_returns_expired(self) -> None:
+        """Test that negative timedeltas return 'Expired'."""
+        td = timedelta(seconds=-1)
+        assert _format_timedelta(td) == "Expired"
+
+        td = timedelta(days=-1)
+        assert _format_timedelta(td) == "Expired"
+
+    def test_zero_seconds(self) -> None:
+        """Test formatting of 0 seconds."""
+        td = timedelta(seconds=0)
+        assert _format_timedelta(td) == "0 seconds"
+
+    def test_seconds_range(self) -> None:
+        """Test formatting of seconds (1-59)."""
+        assert _format_timedelta(timedelta(seconds=1)) == "1 seconds"
+        assert _format_timedelta(timedelta(seconds=30)) == "30 seconds"
+        assert _format_timedelta(timedelta(seconds=59)) == "59 seconds"
+
+    def test_one_minute_singular(self) -> None:
+        """Test singular form for 1 minute."""
+        td = timedelta(minutes=1)
+        assert _format_timedelta(td) == "1 minute"
+
+    def test_minutes_plural(self) -> None:
+        """Test plural form for multiple minutes."""
+        assert _format_timedelta(timedelta(minutes=2)) == "2 minutes"
+        assert _format_timedelta(timedelta(minutes=30)) == "30 minutes"
+        assert _format_timedelta(timedelta(minutes=59)) == "59 minutes"
+
+    def test_one_hour_singular(self) -> None:
+        """Test singular form for 1 hour."""
+        td = timedelta(hours=1)
+        assert _format_timedelta(td) == "1 hour"
+
+    def test_hours_plural(self) -> None:
+        """Test plural form for multiple hours."""
+        assert _format_timedelta(timedelta(hours=2)) == "2 hours"
+        assert _format_timedelta(timedelta(hours=12)) == "12 hours"
+        assert _format_timedelta(timedelta(hours=23)) == "23 hours"
+
+    def test_one_day_singular(self) -> None:
+        """Test singular form for 1 day."""
+        td = timedelta(days=1)
+        assert _format_timedelta(td) == "1 day"
+
+    def test_days_plural(self) -> None:
+        """Test plural form for multiple days (up to 13)."""
+        assert _format_timedelta(timedelta(days=2)) == "2 days"
+        assert _format_timedelta(timedelta(days=7)) == "7 days"
+        assert _format_timedelta(timedelta(days=13)) == "13 days"
+
+    def test_weeks_threshold(self) -> None:
+        """Test that 14+ days converts to weeks."""
+        assert _format_timedelta(timedelta(days=14)) == "2 weeks"
+        assert _format_timedelta(timedelta(days=21)) == "3 weeks"
+
+    def test_one_week_singular(self) -> None:
+        """Test singular form would apply for 1 week (7-13 days show as days)."""
+        # Note: 7-13 days show as days, not weeks
+        # 14 days = 2 weeks (plural)
+        # So singular "week" requires exactly 7 days to round down to 1 week
+        # But 7 days is < 14, so it shows as "7 days"
+        # First week display is at 14 days = 2 weeks
+        pass  # Covered by days_plural test
+
+    def test_boundary_between_units(self) -> None:
+        """Test boundaries between time units."""
+        # 59 seconds -> seconds
+        assert _format_timedelta(timedelta(seconds=59)) == "59 seconds"
+        # 60 seconds -> 1 minute
+        assert _format_timedelta(timedelta(seconds=60)) == "1 minute"
+
+        # 59 minutes -> minutes
+        assert _format_timedelta(timedelta(minutes=59)) == "59 minutes"
+        # 60 minutes -> 1 hour
+        assert _format_timedelta(timedelta(minutes=60)) == "1 hour"
+
+        # 23 hours -> hours
+        assert _format_timedelta(timedelta(hours=23)) == "23 hours"
+        # 24 hours -> 1 day
+        assert _format_timedelta(timedelta(hours=24)) == "1 day"
+
+
+class TestFormatTimeAgo:
+    """Tests for _format_time_ago function."""
+
+    def test_formats_as_time_ago(self) -> None:
+        """Test that result includes 'ago' suffix."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(minutes=5)
+        result = _format_time_ago(past)
+        assert result.endswith(" ago")
+
+    def test_timezone_aware_datetime(self) -> None:
+        """Test with timezone-aware datetime."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(hours=2)
+        result = _format_time_ago(past)
+        assert "2 hours ago" == result
+
+    def test_timezone_naive_datetime_assumed_utc(self) -> None:
+        """Test that timezone-naive datetime is assumed to be UTC."""
+        now = datetime.now(timezone.utc)
+        # Create naive datetime that would be 1 hour ago if interpreted as UTC
+        past_naive = (now - timedelta(hours=1)).replace(tzinfo=None)
+        result = _format_time_ago(past_naive)
+        assert "1 hour ago" == result
+
+    def test_recent_time(self) -> None:
+        """Test formatting of very recent times."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(seconds=30)
+        result = _format_time_ago(past)
+        assert "seconds ago" in result
+
+    def test_minutes_ago(self) -> None:
+        """Test formatting of minutes ago."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(minutes=45)
+        result = _format_time_ago(past)
+        assert "45 minutes ago" == result
+
+    def test_hours_ago(self) -> None:
+        """Test formatting of hours ago."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(hours=5)
+        result = _format_time_ago(past)
+        assert "5 hours ago" == result
+
+    def test_days_ago(self) -> None:
+        """Test formatting of days ago."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(days=3)
+        result = _format_time_ago(past)
+        assert "3 days ago" == result


### PR DESCRIPTION
## Summary

- Request `offline_access` scope by default for long-lived refresh tokens
- Add static API key support as alternative to OAuth (`api_key` config field)
- Show human-readable token expiry in `mcpl auth status` (e.g., "Expires in 45 minutes")
- Display refresh token status with auto-refresh indicator
- Improve error messages with agent workflow guidance

## Motivation

These changes make MCPL work seamlessly with coding agents that cannot complete interactive OAuth flows. Users authenticate once, and agents can use those credentials for weeks/months.

## Changes

| File | Changes |
|------|---------|
| `mcp_launchpad/oauth/flow.py` | Add `offline_access` to scopes automatically |
| `mcp_launchpad/config.py` | Add `api_key` field to ServerConfig |
| `mcp_launchpad/connection.py` | Support API key injection, improve error messages |
| `mcp_launchpad/oauth/manager.py` | Add human-readable expiry to AuthStatus |
| `mcp_launchpad/cli.py` | Update auth status display with new fields |

## Test plan

- [x] All 538 tests pass
- [ ] Manual test: `mcpl auth login` includes `offline_access` in URL
- [ ] Manual test: `mcpl auth status` shows human-readable expiry
- [ ] Manual test: API key config works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)